### PR TITLE
Added optional support for ranges in the profile download mode

### DIFF
--- a/codept/code/profile.py
+++ b/codept/code/profile.py
@@ -9,6 +9,8 @@ def extract_post_info(post_card, base_url):
     post_info = {}
     post_info['link'] = urljoin(base_url, post_card.find('a')['href'])
     post_info['title'] = post_card.find('header', class_='post-card__header').text.strip()
+    
+    post_info['id'] = int(post_card.find('a')['href'].split('/')[-1])
 
     attachments_div = post_card.find('div', string=lambda x: x and 'attachments' in x.lower())
     post_info['attachments'] = attachments_div.text.strip() if attachments_div else "No attachments"
@@ -166,6 +168,35 @@ with open("code/profileconfig.json", "r") as f:
 # URL base fornecida
 base_url = input("Por favor, insira a URL do Perfil: ")
 
+input_choice = input("Press 1 to download all, or 2 to provide starting and ending post URLs: ")
+
+mode = "all"
+if input_choice == "2":
+    start_url = input("Provide starting/newer post URL (enter 0 for newest post): ")
+    end_url = input("Provide ending/older post URL (enter 0 for oldest post): ")
+
+    start_id = int(start_url.split('/')[-1])
+    end_id = int(end_url.split('/')[-1])
+
+    if start_id:
+        if end_id:
+            mode = "range"
+            if start_id < end_id:
+                start_id, end_id = end_id, start_id
+            print("Downloading posts between", start_id, "and", end_id, "...")
+        else:
+            mode = "older"
+            print("Downloading posts older than", start_id, "...")
+    else:
+        if end_id:
+            mode = "newer"
+            print("Downloading posts newer than", end_id, "...")
+        else:
+            mode = "all"
+
+if mode == "all":
+    print("Downloading all posts ...")
+
 # Variável para armazenar todos os posts
 all_posts = []
 
@@ -199,6 +230,17 @@ while True:
 # Filtrar os posts com base nas configurações de profileconfig.json
 filtered_posts = []
 for post in all_posts:
+    if mode != "all":
+        if mode == "range":
+            if not(start_id >= post['id'] and post['id'] >= end_id):
+                continue
+        if mode == "newer":
+            if not(post['id'] >= end_id):
+                continue
+        if mode == "older":
+            if not(post['id'] <= start_id):
+                continue    
+    
     has_media = post['image'] != "No image available" or post['attachments'] != "No attachments"
 
     if profile_config['ambos']:


### PR DESCRIPTION
Hello,

I made some minor updates to the code to add the capability to specify URL ranges in profile download mode. The user is given the ability to specify a starting post URL and ending post URL, and only posts from within that range will be downloaded in this mode. 

![Screenshot 2024-09-02 200946](https://github.com/user-attachments/assets/fa6f4113-bf91-4000-b269-3647f4aed0b3)

_Note: You can provide a **0** to either of the two inputs, and it will use it as a shortcut for either the newest or oldest post._

Users can skip this range feature entirely simply by pressing 1 or just tapping Enter.

![Screenshot 2024-09-02 201443](https://github.com/user-attachments/assets/3c18586d-da38-494d-a80f-b187f481eeb3)

I realize there is a more involved way to do this using the JSON file; however, I found this inline method quicker and easier to use. The cases where I believe it would be useful are:

- When the download of a large profile gets interrupted (this happened several times today, prompting me to write this update)
    - Now you can easily resume the download by specifying the last successful post as 'start' and **0** as the 'end' (i.e. oldest post)
- When a number of new posts are uploaded but you don't wish to redownload the entire profile
    - You can download the new files by specifying **0** as the 'start' (i.e. newest post) and the last post you previously downloaded as 'end'

I have made identical updates to both the EN and PT _profile.py_ files. Unfortunately, I had to leave the text in English as I don't know the appropriate translations. However, the functionality is made identical to prevent any overhead in project maintenance.

If you feel like this feature may be of any use to others, it would be great if you would consider my PR. I would be happy to implement any fixes or modifications as per this project's requirements.

Thank you for developing this extremely useful code!
