### PR TITLE
Fix errors with Python 2 main.py

### DIFF
--- a/codeen/main.py
+++ b/codeen/main.py
@@ -8,28 +8,28 @@ def clear_screen():
 def download_posts():
     clear_screen()
     print("Executing script to download specific posts...")
-    os.system('python code/post.py')
+    os.system('python3 code/post.py')
     input("\nPress Enter to return to the menu...")
 
 # Function to download all posts from a profile
 def download_all_profile_posts():
     clear_screen()
     print("Executing script to download all posts from a profile...")
-    os.system('python code/profile.py')
+    os.system('python3 code/profile.py')
     input("\nPress Enter to return to the menu...")
 
 # Function to download DMs from a profile
 def download_dms():
     clear_screen()
     print("Executing script to download DMs from a profile...")
-    os.system('python code/dm.py')
+    os.system('python3 code/dm.py')
     input("\nPress Enter to return to the menu...")
 
 # Function to customize download settings
 def customize_settings():
     clear_screen()
     print("Executing script to customize download settings...")
-    os.system('python settings.py')
+    os.system('python3 settings.py')
     input("\nPress Enter to return to the menu...")
 
 # Check and install necessary dependencies


### PR DESCRIPTION
Most systems still run python2 alongside python3. If you use python you run the main script with python3 and execute the subscripts with python2 which is default. This returns errors.